### PR TITLE
including gch in TI calc in calulate_wake

### DIFF
--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -536,7 +536,8 @@ class FlowField():
                 rotated_x, rotated_y, rotated_z, turbine, coord, deflection, self)
 
             # include turbulence model for the gaussian wake model from Porte-Agel
-            if self.wake.velocity_model.model_string == 'gauss':
+            if self.wake.velocity_model.model_string == 'gauss' or \
+                self.wake.velocity_model.model_string == 'gauss_curl_hybrid':
 
                 # compute area overlap of wake on other turbines and update downstream turbine turbulence intensities
                 for coord_ti, turbine_ti in sorted_map:


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST IS READY TO MERGE

**Feature or improvement description**
Added gch model to TI calculation in `flow_field.py.calculate_wake()`

**Related issue, if one exists**
None.

**Impacted areas of the software**
`flow_field.py`

**Additional supporting information**
Upon breaking out the gch model into a separate class, the `if model == gauss` check no longer included the gch calculations for updating turbine TI's.

**Test results, if applicable**
`example_0006b` now prints out the powers for the two models as:
```
Power in baseline
Gauss [1690.35830959  614.77345831  756.5347801 ]
GCH [1690.35830959  614.77345831  756.5347801 ]
```
