### PR TITLE
Limiting wind speeds in AEP calc to below-rated farm power only

### DIFF
--- a/examples/performance_analysis/performance_cases/case_5a_aep_3x3_simple.py
+++ b/examples/performance_analysis/performance_cases/case_5a_aep_3x3_simple.py
@@ -19,9 +19,9 @@ import pickle
 import itertools
 
 import numpy as np
+import matplotlib.pyplot as plt
 
 import floris.tools as wfct
-import matplotlib.pyplot as plt
 
 
 # PARAMETERS
@@ -73,7 +73,7 @@ freq = np.ones_like(ws_list) / num_cases
 # # Now check the timing
 print("===START TEST===")
 start = time.perf_counter()
-power_result = fi.get_farm_AEP(wd_list, ws_list, freq)
+power_result = fi.get_farm_AEP(wd_list, ws_list, freq, limit_ws=True)
 end = time.perf_counter()
 elapsed_time = end - start
 

--- a/examples/performance_analysis/performance_cases/case_5b_aep_3x3_simple.py
+++ b/examples/performance_analysis/performance_cases/case_5b_aep_3x3_simple.py
@@ -19,9 +19,9 @@ import pickle
 import itertools
 
 import numpy as np
+import matplotlib.pyplot as plt
 
 import floris.tools as wfct
-import matplotlib.pyplot as plt
 
 
 # PARAMETERS
@@ -73,7 +73,7 @@ freq = np.ones_like(ws_list) / num_cases
 # # Now check the timing
 print("===START TEST===")
 start = time.perf_counter()
-power_result = fi.get_farm_AEP(wd_list, ws_list, freq)
+power_result = fi.get_farm_AEP(wd_list, ws_list, freq, limit_ws=True)
 end = time.perf_counter()
 elapsed_time = end - start
 

--- a/examples/performance_analysis/performance_cases/case_6a_aep_10x10_simple.py
+++ b/examples/performance_analysis/performance_cases/case_6a_aep_10x10_simple.py
@@ -19,9 +19,9 @@ import pickle
 import itertools
 
 import numpy as np
+import matplotlib.pyplot as plt
 
 import floris.tools as wfct
-import matplotlib.pyplot as plt
 
 
 # PARAMETERS
@@ -73,7 +73,7 @@ freq = np.ones_like(ws_list) / num_cases
 # # Now check the timing
 print("===START TEST===")
 start = time.perf_counter()
-power_result = fi.get_farm_AEP(wd_list, ws_list, freq)
+power_result = fi.get_farm_AEP(wd_list, ws_list, freq, limit_ws=True)
 end = time.perf_counter()
 elapsed_time = end - start
 

--- a/examples/performance_analysis/performance_cases/case_6b_aep_10x10_simple.py
+++ b/examples/performance_analysis/performance_cases/case_6b_aep_10x10_simple.py
@@ -19,9 +19,9 @@ import pickle
 import itertools
 
 import numpy as np
+import matplotlib.pyplot as plt
 
 import floris.tools as wfct
-import matplotlib.pyplot as plt
 
 
 # PARAMETERS
@@ -73,7 +73,7 @@ freq = np.ones_like(ws_list) / num_cases
 # # Now check the timing
 print("===START TEST===")
 start = time.perf_counter()
-power_result = fi.get_farm_AEP(wd_list, ws_list, freq)
+power_result = fi.get_farm_AEP(wd_list, ws_list, freq, limit_ws=True)
 end = time.perf_counter()
 elapsed_time = end - start
 


### PR DESCRIPTION
Modified `FlorisInterface.get_farm_AEP` by adding an option to calculate farm power only for wind speeds below rated farm power. For a given wind direction, when the farm power changes by less than some amount (default 0.1%), for all higher wind speeds, the last calculated power will be used.  Note, get_farm_AEP is backward compatible, it defaults to not using the wind speed limit. 

Examples 5a, 5b, 6a, and 6b have been updated to use the wind speed limit. This reduces the run time by ~33%. AEP changes by 0.3%, though. The sort of large difference is due to: 1) Because we interpolate Cp instead of power, above rated power jumps around a lot, so assuming constant power above rated is not valid. Should improve when we switch to interpolating power. 2) we're placing equal weight on all wind speed frequencies, so the differences above rated have a bigger impact than with a Weibull distribution. 

